### PR TITLE
Force scope change on shared PluginListGenerator to generate all scopes (M2.4.1 compatibility)

### DIFF
--- a/Generator/CompiledPluginList.php
+++ b/Generator/CompiledPluginList.php
@@ -107,9 +107,12 @@ class CompiledPluginList extends PluginList
     protected function _loadScopedData()
     {
         $closure = function ($scope) {
+            $previousScope = $this->scopeConfig->getCurrentScope();
             $this->scopeConfig->setCurrentScope($scope);
+            return $previousScope;
         };
-        $closure->call($this->pluginListGenerator, $this->_configScope->getCurrentScope());
+        $previousScope = $closure->call($this->pluginListGenerator, $this->_configScope->getCurrentScope());
         parent::_loadScopedData();
+        $closure->call($this->pluginListGenerator, $previousScope);
     }
 }


### PR DESCRIPTION
Fixes the compatibility with latest Magento (dev-develop, 2.4.1.-beta2), enables gathering plugin data from all scopes.
Fixes issue #3 
Solution suggested by @meandor-ua 