### PR TITLE
Add cache.xml file

### DIFF
--- a/etc/cache.xml
+++ b/etc/cache.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Cache/etc/cache.xsd">
+    <type name="compiled_plugins" translate="label,description" instance="Creatuity\Interception\Generator\FileCache">
+        <label>Compiled Plugins Config</label>
+        <description>Plugin configuration</description>
+    </type>
+</config>


### PR DESCRIPTION
This makes Magento aware of the compiled_plugins cache definition and the filecache directory, meaning it clears it at appropriate times during development.