### PR TITLE
Remove schema version from module.xml

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Creatuity_Interception" setup_version="1.1.0">
+    <module name="Creatuity_Interception">
     </module>
 </config>


### PR DESCRIPTION
As there is no database schema, there is no reason to declare this. Declaring it forces the user to run setup:upgrade (and causes downtime).