### PR TITLE
move file cache to generated/metadata

### DIFF
--- a/Generator/FileCache.php
+++ b/Generator/FileCache.php
@@ -25,6 +25,7 @@ class FileCache implements CacheInterface
         if ($cachePath === null) {
             $this->cachePath = BP . DIRECTORY_SEPARATOR .
                 DirectoryList::GENERATED . DIRECTORY_SEPARATOR .
+                DirectoryList::GENERATED_METADATA . DIRECTORY_SEPARATOR .
                 'staticcache';
         } else {
             $this->cachePath = $cachePath;


### PR DESCRIPTION
Move file cache to generated/metadata to fix issues in magento cloud and use standard location

note: tests are required before merging this.
