### PR TITLE
Import global functions

### DIFF
--- a/Generator/CompiledInterceptorSubstitution.php
+++ b/Generator/CompiledInterceptorSubstitution.php
@@ -4,6 +4,9 @@ namespace Creatuity\Interception\Generator;
 
 use Magento\Setup\Module\Di\Compiler\Config\Chain\InterceptorSubstitution;
 
+use function array_merge;
+use function substr;
+
 /**
  * Class CompiledInterceptorSubstitution adds required parameters to interceptor constructor
  */

--- a/Generator/CompiledPluginList.php
+++ b/Generator/CompiledPluginList.php
@@ -5,13 +5,15 @@ namespace Creatuity\Interception\Generator;
 use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Config\ReaderInterface;
 use Magento\Framework\Config\ScopeInterface;
-use Magento\Framework\Interception\PluginList\PluginList;
+use Magento\Framework\Interception\Definition\Runtime as InterceptionDefinitionRuntime;
 use Magento\Framework\Interception\ObjectManager\ConfigInterface;
+use Magento\Framework\Interception\PluginList\PluginList;
 use Magento\Framework\Interception\PluginListGenerator;
 use Magento\Framework\ObjectManager\Config\Reader\Dom;
-use Magento\Framework\ObjectManager\Relations\Runtime as ObjectManagerRelationsRuntime;
-use Magento\Framework\Interception\Definition\Runtime as InterceptionDefinitionRuntime;
 use Magento\Framework\ObjectManager\Definition\Runtime as ObjectManagerDefinitionRuntime;
+use Magento\Framework\ObjectManager\Relations\Runtime as ObjectManagerRelationsRuntime;
+
+use function class_exists;
 
 /**
  * Class CompiledPluginList

--- a/Generator/FileCache.php
+++ b/Generator/FileCache.php
@@ -8,6 +8,20 @@ namespace Creatuity\Interception\Generator;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Config\CacheInterface;
 
+use function dirname;
+use function file_exists;
+use function file_put_contents;
+use function glob;
+use function is_dir;
+use function is_file;
+use function mkdir;
+use function str_replace;
+use function unlink;
+use function var_export;
+
+use const BP;
+use const DIRECTORY_SEPARATOR;
+
 /**
  * Class FileCache
  */


### PR DESCRIPTION
- import all global functions in main codebase
- add leading slash for globla functions in generated code

should save some opcodes calls as other popular libs do. e.g. symfony https://github.com/symfony/symfony/blob/7.2/src/Symfony/Bridge/Doctrine/ArgumentResolver/EntityValueResolver.php

basically it can be fixed by php-cs-fixer or rector automatically smth like

```
php tools/php-cs-fixer/vendor/bin/php-cs-fixer fix ./magento2-interceptors --rules=native_function_invocation,native_constant_invocation --allow-risky=yes
php tools/php-cs-fixer/vendor/bin/php-cs-fixer fix ./magento2-interceptors --rules='{"global_namespace_import": {"import_constants": true, "import_classes": false, "import_functions": true}}' --allow-risky=yes
```