### PR TITLE
#14 - fix: check for any disabled scopes to exclude when plugin is gl…

### DIFF
--- a/Generator/CompiledInterceptor.php
+++ b/Generator/CompiledInterceptor.php
@@ -720,7 +720,7 @@ class CompiledInterceptor extends EntityAbstract
                 $config
             );
             foreach ($disabledScopes as $scope => $conf) {
-                $config[] = [$scope => []];
+                $config[$scope] = [];
             }
         }
 

--- a/Generator/CompiledInterceptor.php
+++ b/Generator/CompiledInterceptor.php
@@ -712,6 +712,18 @@ class CompiledInterceptor extends EntityAbstract
     private function getScopeCasesFromConfig($config)
     {
         $cases = [];
+
+        //if global scope is enabled, check for any disabled scopes to exclude
+        if (array_key_exists('global', $config)) {
+            $disabledScopes = array_diff_key(
+                $this->areasPlugins->getPluginsConfigForAllAreas(),
+                $config
+            );
+            foreach ($disabledScopes as $scope => $conf) {
+                $config[] = [$scope => []];
+            }
+        }
+
         //group cases by config
         foreach ($config as $scope => $conf) {
             $caseStr = "\tcase '$scope':";


### PR DESCRIPTION
This PR aims to fix #14 

The issue is that scopes where a plugin is disabled (etc/<scope>/di.xml) aren't included in the config array, so the case of a disabled plugin is skipped over.

Before the change, the Interceptor method looks like:
```    /**
     * {@inheritdoc}
     */
    public function getProduct()
    {
        $arguments = \func_get_args();
        $this->____plugin_creatuity_plugin_test()->beforeGetProduct($this, ...\array_values($arguments));

        return parent::getProduct(...\array_values($arguments));
    }
```

And after:
``` /**
     * {@inheritdoc}
     */
    public function getProduct()
    {
        switch ($this->____scope->getCurrentScope()) {
        	case 'global':
        	case 'adminhtml':
        	case 'graphql':
        	case 'crontab':
        	case 'webapi_rest':
        	case 'webapi_soap':
        	case 'primary':
        		$arguments = \func_get_args();
        		$this->____plugin_creatuity_plugin_test()->beforeGetProduct($this, ...\array_values($arguments));
        		
        		return parent::getProduct(...\array_values($arguments));
        	default:
        		$arguments = \func_get_args();
        		return parent::getProduct(...\array_values($arguments));
        }
    }
```


