### PR TITLE
Fix PHP 8.4 compatibility #24

### DIFF
--- a/Generator/CompiledInterceptor.php
+++ b/Generator/CompiledInterceptor.php
@@ -75,9 +75,9 @@ class CompiledInterceptor extends EntityAbstract
         AreasPluginList $areasPlugins,
         $sourceClassName = null,
         $resultClassName = null,
-        Io $ioObject = null,
-        CodeGeneratorInterface $classGenerator = null,
-        DefinedClasses $definedClasses = null
+        ?Io $ioObject = null,
+        ?CodeGeneratorInterface $classGenerator = null,
+        ?DefinedClasses $definedClasses = null
     ) {
         parent::__construct(
             $sourceClassName,
@@ -270,8 +270,10 @@ class CompiledInterceptor extends EntityAbstract
      * @param array $properties
      * @return array
      */
-    private function injectPropertiesSettersToConstructor(ReflectionMethod $parentConstructor = null, $properties = [])
-    {
+    private function injectPropertiesSettersToConstructor(
+        ?ReflectionMethod $parentConstructor = null,
+        $properties = []
+    ) {
         if ($parentConstructor == null) {
             $parameters = [];
             $body = [];

--- a/Generator/CompiledPluginList.php
+++ b/Generator/CompiledPluginList.php
@@ -31,8 +31,8 @@ class CompiledPluginList extends PluginList
     public function __construct(
         ObjectManager $objectManager,
         ScopeInterface $scope,
-        ReaderInterface $reader = null,
-        ConfigInterface $omConfig = null,
+        ?ReaderInterface $reader = null,
+        ?ConfigInterface $omConfig = null,
         $cachePath = null
     ) {
         if (!$reader || !$omConfig) {


### PR DESCRIPTION
This adds explicit null to implicitly nullable types across the module. This is necessary for compatibility with PHP 8.4, which is supported as of Magento 2.4.8 last week. Fixes #24 

The ?Type syntax is valid since PHP 7.1, so backwards compatibility should not be an issue.